### PR TITLE
Change background of tab row when unfocused to a less accented color

### DIFF
--- a/rose-pine-dawn.theme.json
+++ b/rose-pine-dawn.theme.json
@@ -7,7 +7,7 @@
   },
   "tabRow": {
     "background": "#F2E9E1FF",
-    "unfocusedBackground": "#797593FF"
+    "unfocusedBackground": "#FFFAF3FF"
   },
   "window": {
     "applicationTheme": "light",

--- a/rose-pine-moon.theme.json
+++ b/rose-pine-moon.theme.json
@@ -7,7 +7,7 @@
   },
   "tabRow": {
     "background": "#393552FF",
-    "unfocusedBackground": "#908CAAFF"
+    "unfocusedBackground": "#2A273FFF"
   },
   "window": {
     "applicationTheme": "dark",

--- a/rose-pine.theme.json
+++ b/rose-pine.theme.json
@@ -7,7 +7,7 @@
   },
   "tabRow": {
     "background": "#26233AFF",
-    "unfocusedBackground": "#908CAAFF"
+    "unfocusedBackground": "#1F1D2EFF"
   },
   "window": {
     "applicationTheme": "dark",


### PR DESCRIPTION
Unfocused background of the tab row used `subtle`. Because of this, color of inactive windows was more accented than that of the active one.

It was replaced with a more suitable `surface`. This also matches Rosé Pine’s recommendations: `subtle` is meant for foreground elements, not background. Additionally, it aligns with the style of Windows: title bars of standard apps have an accented color for the active window (or just white/black if you do not use an accent color), while inactive windows are lighter/same (white) for light theme or darker/same (black) for dark theme.

| Before | After |
|--------|--------|
| <img width="785" height="609" alt="classic-before" src="https://github.com/user-attachments/assets/7dd8ce68-3a21-469f-ab77-f5c822bc9d21" /> | <img width="801" height="633" alt="classic-after" src="https://github.com/user-attachments/assets/d6be0e1c-44f7-4283-9d5a-ce653d2945c8" /> |
| <img width="779" height="593" alt="dawn-before" src="https://github.com/user-attachments/assets/9eac950b-503e-4ae8-a352-95cc8f38901a" /> | <img width="795" height="627" alt="dawn-after" src="https://github.com/user-attachments/assets/352d114f-337d-409f-a652-2c8242916a49" /> |